### PR TITLE
Fix package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "ideias-webscraper",
+    "name": "ideas-webscraper",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "ideias-webscraper",
+            "name": "ideas-webscraper",
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "ideias-webscraper",
+    "name": "ideas-webscraper",
     "version": "1.0.0",
     "description": "Projeto para raspar dados do YouTube (título, link, visualizações, thumbnail)",
     "main": "server.js",


### PR DESCRIPTION
## Summary
- update `name` from `ideias-webscraper` to `ideas-webscraper`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68416a79e8288321aa1630685a4e0890