### PR TITLE
Fix puppeteer path

### DIFF
--- a/youtubeScraper.js
+++ b/youtubeScraper.js
@@ -4,7 +4,7 @@ async function buscarVideos(keyword, maxVideos = 10) {
   const browser = await puppeteer.launch({
     headless: true,
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    executablePath: '/usr/bin/google-chrome-stable',
+    executablePath: puppeteer.executablePath(),
   });
 
   const page = await browser.newPage();


### PR DESCRIPTION
## Summary
- use the default chromium executable when launching Puppeteer

## Testing
- `node -e "const s=require('./youtubeScraper');s.buscarVideos('javascript tutorial',1).then(r=>console.log('OK'));"` *(fails: net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_684169c229008321ac036f7cd48e748d